### PR TITLE
refactor: refactor to relative user directories and new moonraker config dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Run the test macro on the printer:
     TEST_PROBE_ACCURACY
 
 It will continuously run `PROBE_ACCURACY` while heating up the bed, soaking the bed, heating up the hotend, and
-soaking the hotend. See below if you want to change the temperatures or soak times.  The default will heat the
+soaking the hotend.  See below if you want to change the temperatures or soak times.  The default will heat the
 bed to 110, soak for 30 minutes, then heat the hotend to 150, and soak for 15 minutes - so this test will
 probably take over an hour to run.  Get some coffee while you wait.
 
@@ -108,11 +108,11 @@ The temperatures are in Celsius.  The defaults are as follows:
 `START_IDLE_MINUTES` is the amount of time the test will wait at the start before heating up the bed.
 
 Setting `BED_TEMP` or `EXTRUDER_TEMP` to `-1` allows you to disable heating and soaking the bed or
-the extruder. Thus you could run a test with just the extruder and without ever turning on the bed.
+the extruder.  Thus you could run a test with just the extruder and without ever turning on the bed.
 
 `DWELL_SECONDS` is the approximate amount of time between running `PROBE_ACCURACY` commands.  If
 `DWELL_LIFT_Z` is not `-1`, then the toolhead will be lifted to the specified Z after completing
-each `PROBE_ACCURACY`. This is intended to allow the probe to cool away from the bed between probes.
+each `PROBE_ACCURACY`.  This is intended to allow the probe to cool away from the bed between probes.
 
 `END_IDLE_MINUTES` is the amount of time the test will wait after turning off the heaters at the end,
 while still measuring probe accuracy.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,25 @@ Installation
 Create a Python environment for this script.  Use ssh to log in to the Raspberry Pi, and run the following:
 
     sudo apt install python3-venv
-    python3 -m venv /home/pi/plotly-env
-    /home/pi/plotly-env/bin/pip install -U plotly
-    mkdir /home/pi/probe_accuracy
+    python3 -m venv ~/plotly-env
+    ~/plotly-env/bin/pip install -U plotly
+    mkdir ~/probe_accuracy
 
-Download `probe_accuracy.py` from this repository and copy it into `/home/pi/probe_accuracy/` on the Raspberry Pi.
+Download `probe_accuracy.py` from this repository and copy it into `~/probe_accuracy/` on the Raspberry Pi:
+```bash
+cd ~/probe_accuracy
+wget -O probe_accuracy.py https://raw.githubusercontent.com/KiloQubit/probe_accuracy/master/probe_accuracy.py
+```
 
 Download `test_probe_accuracy.cfg` from this repository and copy it to the directory containing your
-`printer.cfg` - it's `/home/pi/klipper_config/` if you're using
-[MainsailOS](https://github.com/raymondh2/MainsailOS).  Edit your `printer.cfg` and add the
-following on a new line:
+`printer.cfg` - it's `~/printer_data/config/` if you're using a current version of 
+[MainsailOS](https://github.com/mainsail-crew/MainsailOS):
+```bash
+cd ~/printer_data/config
+wget -O test_probe_accuracy.cfg https://raw.githubusercontent.com/KiloQubit/probe_accuracy/master/test_probe_accuracy.cfg
+```
+
+Edit your `printer.cfg` and add the following on a new line:
 
     [include test_probe_accuracy.cfg]
 
@@ -35,7 +44,7 @@ Home and level your printer (G32 on a [VORON 2](https://vorondesign.com)).  Posi
 where you want to test the probe, probably in the center of the bed.  Use ssh to log in to the Raspberry
 Pi and run the following to start the data collection:
 
-    /home/pi/plotly-env/bin/python3 /home/pi/probe_accuracy/probe_accuracy.py
+    ~/plotly-env/bin/python3 ~/probe_accuracy/probe_accuracy.py
 
 > **Warning**
 > Leave that ssh session/window open for the duration of the test.
@@ -47,14 +56,14 @@ Pi and run the following to start the data collection:
 Alternatively, if you don't want to leave the window open, or have a bad network connection to the Pi, you
 can run the script in the background, and then you don't have to leave the ssh session open:
 
-    nohup /home/pi/plotly-env/bin/python3 /home/pi/probe_accuracy/probe_accuracy.py >/tmp/probe_accuracy.log 2>&1 &
+    nohup ~/plotly-env/bin/python3 ~/probe_accuracy/probe_accuracy.py >/tmp/probe_accuracy.log 2>&1 &
 
 Run the test macro on the printer:
 
     TEST_PROBE_ACCURACY
 
 It will continuously run `PROBE_ACCURACY` while heating up the bed, soaking the bed, heating up the hotend, and
-soaking the hotend.  See below if you want to change the temperatures or soak times.  The default will heat the
+soaking the hotend. See below if you want to change the temperatures or soak times.  The default will heat the
 bed to 110, soak for 30 minutes, then heat the hotend to 150, and soak for 15 minutes - so this test will
 probably take over an hour to run.  Get some coffee while you wait.
 
@@ -72,7 +81,7 @@ Plotting Existing Data
 
 If you already have a JSON data file and want to generate a chart from it, you can use the `--plot-only` option.
 
-    /home/pi/plotly-env/bin/python3 /home/pi/probe_accuracy/probe_accuracy.py \
+    ~/plotly-env/bin/python3 ~/probe_accuracy/probe_accuracy.py \
         --plot-only \
         --data-file /tmp/probe_accuracy.json \
         --chart-file /tmp/probe_accuracy.html
@@ -99,11 +108,11 @@ The temperatures are in Celsius.  The defaults are as follows:
 `START_IDLE_MINUTES` is the amount of time the test will wait at the start before heating up the bed.
 
 Setting `BED_TEMP` or `EXTRUDER_TEMP` to `-1` allows you to disable heating and soaking the bed or
-the extruder.  Thus you could run a test with just the extruder and without ever turning on the bed.
+the extruder. Thus you could run a test with just the extruder and without ever turning on the bed.
 
 `DWELL_SECONDS` is the approximate amount of time between running `PROBE_ACCURACY` commands.  If
 `DWELL_LIFT_Z` is not `-1`, then the toolhead will be lifted to the specified Z after completing
-each `PROBE_ACCURACY`.  This is intended to allow the probe to cool away from the bed between probes.
+each `PROBE_ACCURACY`. This is intended to allow the probe to cool away from the bed between probes.
 
 `END_IDLE_MINUTES` is the amount of time the test will wait after turning off the heaters at the end,
 while still measuring probe accuracy.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create a Python environment for this script.  Use ssh to log in to the Raspberry
 Download `probe_accuracy.py` from this repository and copy it into `~/probe_accuracy/` on the Raspberry Pi:
 ```bash
 cd ~/probe_accuracy
-wget -O probe_accuracy.py https://raw.githubusercontent.com/KiloQubit/probe_accuracy/master/probe_accuracy.py
+wget -O probe_accuracy.py https://raw.githubusercontent.com/KiloQubit/probe_accuracy/main/probe_accuracy.py
 ```
 
 Download `test_probe_accuracy.cfg` from this repository and copy it to the directory containing your
@@ -28,7 +28,7 @@ Download `test_probe_accuracy.cfg` from this repository and copy it to the direc
 [MainsailOS](https://github.com/mainsail-crew/MainsailOS):
 ```bash
 cd ~/printer_data/config
-wget -O test_probe_accuracy.cfg https://raw.githubusercontent.com/KiloQubit/probe_accuracy/master/test_probe_accuracy.cfg
+wget -O test_probe_accuracy.cfg https://raw.githubusercontent.com/KiloQubit/probe_accuracy/main/test_probe_accuracy.cfg
 ```
 
 Edit your `printer.cfg` and add the following on a new line:

--- a/probe_accuracy.py
+++ b/probe_accuracy.py
@@ -32,7 +32,7 @@ from plotly.subplots import make_subplots
 home_dir = os.path.expanduser('~')
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--klippy-uds', default=os.path.join(home_dir, 'printer_data/comms/klippy.sock')
+parser.add_argument('--klippy-uds', default=os.path.join(home_dir, 'printer_data/comms/klippy.sock'))
 parser.add_argument('--data-file', default='/tmp/probe_accuracy.json')
 parser.add_argument('--chart-file', default='/tmp/probe_accuracy.html')
 parser.add_argument('--plot-only', action='store_true',

--- a/probe_accuracy.py
+++ b/probe_accuracy.py
@@ -1,15 +1,15 @@
 # Create a Python environment for this script.  Use ssh to log in to the pi, and run the following:
 #
 #     sudo apt install python3-venv
-#     python3 -m venv /home/pi/plotly-env
-#     /home/pi/plotly-env/bin/pip install -U plotly
-#     mkdir /home/pi/probe_accuracy
+#     python3 -m venv ~/plotly-env
+#     ~/plotly-env/bin/pip install -U plotly
+#     mkdir ~/probe_accuracy
 #
-# Download probe_accuracy.py and copy it to the pi into /home/pi/probe_accuracy/ .
+# Download probe_accuracy.py and copy it to the pi into ~/probe_accuracy/ .
 #
 # To collect data, ssh into the pi and run the below command before doing TEST_PROBE_ACCURACY:
 #
-#     /home/pi/plotly-env/bin/python3 /home/pi/probe_accuracy/probe_accuracy.py
+#     ~/plotly-env/bin/python3 ~/probe_accuracy/probe_accuracy.py
 #
 # Leave that ssh session/window open for the duration of the test.  After the test completes, the
 # chart should be in /tmp/probe_accuracy.html. Copy that file from the pi to your local machine
@@ -20,6 +20,7 @@
 
 import argparse
 import json
+import os
 import re
 import socket
 import time
@@ -28,8 +29,10 @@ from statistics import pstdev
 import plotly.graph_objects as pgo
 from plotly.subplots import make_subplots
 
+home_dir = os.path.expanduser('~')
+
 parser = argparse.ArgumentParser()
-parser.add_argument('--klippy-uds', default='/home/pi/printer_data/comms/klippy.sock')
+parser.add_argument('--klippy-uds', default=os.path.join(home_dir, 'printer_data/comms/klippy.sock')
 parser.add_argument('--data-file', default='/tmp/probe_accuracy.json')
 parser.add_argument('--chart-file', default='/tmp/probe_accuracy.html')
 parser.add_argument('--plot-only', action='store_true',


### PR DESCRIPTION
This PR contains:
- Change all `/home/pi` to `~/`. This is necessary to have usernames independent paths
- Change github.com/raymondh to github.com/mainsail-crew (updated the repo of MainsailOS)
- Add download commands for the config/python files