### PR TITLE
Print parsed responses in terminal

### DIFF
--- a/probe_accuracy.py
+++ b/probe_accuracy.py
@@ -124,6 +124,7 @@ def get_data(klippy_uds: str, data_file: str) -> list:
 
             d = parse_response(response)
             if d:
+                print("Datapoint: ", d)
                 data.append(d)
                 f.write(json.dumps(d, separators=(',', ':')) + '\n')
                 f.flush()
@@ -265,6 +266,7 @@ def main():
         data = load_data(args.data_file)
     else:
         print('Recording data, LEAVE THIS SESSION OPEN UNTIL THE SCRIPT SAYS "DONE"!')
+        print('You should see data printed each time the printer probes, otherwise something is wrong.')
         data = get_data(args.klippy_uds, args.data_file)
 
     write_chart(data, args.chart_file)


### PR DESCRIPTION
First of all, thank you very much for this script. It was very useful in ruling out issues with SlideSwipe on my V0.

I must've hit a problem similar to people in #2 and ended up not receiving any data at all (the `/tmp/probe_accuracy.json` was empty after all, but I wasn't sure if the script only flushes at the end until I looked at it).

This PR thus prints each datapoint as it is parsed, and informs the user that they should see these, otherwise something might be wrong. It's cheap and raw, but at least it gives an indication if something is off before running the script for >30 minutes for nothing.

Example output:
```
Recording data, LEAVE THIS SESSION OPEN UNTIL THE SCRIPT SAYS "DONE"!
You should see data printed each time the printer probes, otherwise something is wrong.
Datapoint:  {'ts': 1712349103.1789894, 'btemp': 27.7, 'bset': 0.0, 'etemp': 27.9, 'eset': 0.0}
Datapoint:  {'ts': 1712349122.0561948, 'z': 16.2295}
Datapoint:  {'ts': 1712349123.685183, 'z': 16.23075}
```